### PR TITLE
Open scenario examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ pip install "pyxodr[dev] @ git+https://github.com/driskai/pyxodr"
 
 Testing is done on the OpenDRIVE example files. I have not included them in this repository as ASAM requires you enter your details to access them, so I assume they don't want them publically distributed through any means other than their own website. You can access them [here](https://www.asam.net/standards/detail/opendrive/).
 
+You can also test on the networks for the OpenSCENARIO example files, obtainable [here](https://www.asam.net/standards/detail/openscenario/).
+
 Once you've downloaded these files, create an `example_networks` subdirectory under `tests` and place them there.
 ```bash
 .

--- a/pyxodr/road_objects/lane.py
+++ b/pyxodr/road_objects/lane.py
@@ -207,8 +207,11 @@ class Lane:
                 f"{self} seems to use both widths and borders; unsupported."
             )
         elif not lane_uses_widths and not lane_uses_borders:
+            if self.type is None:
+                return self.lane_section_reference_line
             raise NotImplementedError(
-                f"{self} seems to use neither widths nor borders; unsupported."
+                f"{self} seems to use neither widths nor borders; unsupported "
+                + "(for type!=none)."
             )
 
         lane_geometries = []

--- a/tests/decrypt_networks.sh
+++ b/tests/decrypt_networks.sh
@@ -2,4 +2,4 @@
 
 # --batch to prevent interactive command
 # --yes to assume "yes" for questions
-gpgtar --decrypt --directory ./tests/ --gpg-args="--passphrase=$EXAMPLE_XODR_PASSKEY --batch --quiet --yes" ./tests/example_networks.gpg 
+gpgtar --decrypt --directory ./ --gpg-args="--passphrase=$EXAMPLE_XODR_PASSKEY --batch --quiet --yes" ./tests/example_networks.gpg 


### PR DESCRIPTION
Update to include the OpenSCENARIO example networks in testing.

This revealed a bug where a none type lane had neither width nor border and threw an error - fixed this by assuming all none type lanes have 0 width.