### PR TITLE
Fix PyPI Issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish to PyPI.org
+on:
+  release:
+    types: [published]
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --upgrade build && python3 -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Read OpenDRIVE files into a class structure that represents road objects as arra
 This class structure implements an API which should act as a middle layer between OpenDRIVE files and other applications, used to create road networks from their coordinates.
 
 <p align="center">
-<img src="docs/source/Ex_LHT-Complex-X-Junction_old_spec.png" width="30%" />
+<img src="https://raw.githubusercontent.com/driskai/pyxodr/main/docs/source/Ex_LHT-Complex-X-Junction_old_spec.png" width="30%" />
 &nbsp; &nbsp; &nbsp; &nbsp;
-<img src="docs/source/UC_2Lane-RoundAbout-3Arms.png" width="30%" />
+<img src="https://raw.githubusercontent.com/driskai/pyxodr/main/docs/source/UC_2Lane-RoundAbout-3Arms.png" width="30%" />
 &nbsp; &nbsp; &nbsp; &nbsp;
-<img src="docs/source/UC_Motorway-Exit-Entry-DirectJunction.png" width="30%" />
+<img src="https://raw.githubusercontent.com/driskai/pyxodr/main/docs/source/UC_Motorway-Exit-Entry-DirectJunction.png" width="30%" />
 </p>
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ This class structure implements an API which should act as a middle layer betwee
 ## Installation
 Install with `pip`:
 ```bash
-pip install git+https://github.com/driskai/pyxodr
-```
-To install extra requirements for developing:
-```bash
-pip install "pyxodr[dev] @ git+https://github.com/driskai/pyxodr"
+pip install pyxodr
 ```
 
 ## Testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,15 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-git-versioning"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.1.3"]
 
-[tool.setuptools.packages.find]
-include = ["pyxodr", "pyxodr.*"]
+[tool.setuptools-git-versioning]
+enabled = true
 
 [project]
 name = "pyxodr"
-version = "0.1.0"
 authors = [
     { name="Hugh Blayney", email="hugh@drisk.ai" },
 ]
@@ -30,6 +29,10 @@ dependencies = [
     "scipy>=1.7.0",
     "Shapely>=1.8.4",
 ]
+dynamic = ["version"]
+
+[tool.setuptools.packages.find]
+include = ["pyxodr", "pyxodr.*"]
 
 [project.urls]
 "Homepage" = "https://github.com/driskai/pyxodr"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project.optional-dependencies]
+dev = ["pytest>=7.1.3"]
+
 [tool.setuptools.packages.find]
 include = ["pyxodr", "pyxodr.*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,5 @@
 [build-system]
-requires = [
-    "setuptools>=61.0",
-    "lxml>=4.9.1",
-    "matplotlib>=3.5.0",
-    "numpy>=1.21.0",
-    "rich>=12.6.0",
-    "scipy>=1.7.0",
-    "Shapely>=1.8.4",
-]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
@@ -29,6 +21,14 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+]
+dependencies = [
+    "lxml>=4.9.1",
+    "matplotlib>=3.5.0",
+    "numpy>=1.21.0",
+    "rich>=12.6.0",
+    "scipy>=1.7.0",
+    "Shapely>=1.8.4",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,17 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = [
+    "setuptools>=61.0",
+    "lxml>=4.9.1",
+    "matplotlib>=3.5.0",
+    "numpy>=1.21.0",
+    "rich>=12.6.0",
+    "scipy>=1.7.0",
+    "Shapely>=1.8.4",
+]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["pyxodr", "pyxodr.*"]
 
 [project]
 name = "pyxodr"

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,4 @@
-from setuptools import find_packages, setup
+import setuptools
 
-requires = [
-    "lxml>=4.9.1",
-    "matplotlib>=3.5.0",
-    "numpy>=1.21.0",
-    "rich>=12.6.0",
-    "scipy>=1.7.0",
-    "Shapely>=1.8.4",
-]
-
-extras = {"dev": ["pytest>=7.1.3"]}
-
-setup(
-    author="Hugh Blayney",
-    author_email="hugh@drisk.ai",
-    description="Read OpenDRIVE files.",
-    install_requires=requires,
-    extras_require=extras,
-    name="pyxodr",
-    version="0.1.0",
-    packages=find_packages(
-        where=".",
-        include=["pyxodr", "pyxodr.*"],
-    ),
-)
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
Fix discovered PyPI issues, including
- Dependencies weren't installed, as I had put them in the wrong part of the `toml` file.
- Images weren't showing, as they were using local paths.

Also updated a few small things; removed duplicated dependency (and other) information from `setup.py`, changed `toml` to get version from github tags.

Also adds a github action to build PyPI package based on github tags. This will have to be tested once merged, and is based on [this guide](https://www.seanh.cc/2022/05/21/publishing-python-packages-from-github-actions/).