### PR TITLE
String road ids

### DIFF
--- a/pyxodr/road_objects/junction.py
+++ b/pyxodr/road_objects/junction.py
@@ -30,7 +30,7 @@ class Junction:
             __connection_attributes.append(connection_xml.attrib)
         return __connection_attributes
 
-    def get_connecting_road_ids(self) -> Set[int]:
+    def get_connecting_road_ids(self) -> Set[str]:
         """
         Return a set of ids of the connecting roads in this junction.
 
@@ -38,20 +38,20 @@ class Junction:
 
         Returns
         -------
-        Set[int]
-            Set of int road ids making up the connecting roads in this junction.
+        Set[str]
+            Set of str road ids making up the connecting roads in this junction.
         """
         _connecting_road_ids = set()
         for connection_attributes in self._connection_attributes_list:
             try:
-                connecting_road_id = int(connection_attributes["connectingRoad"])
+                connecting_road_id = connection_attributes["connectingRoad"]
                 _connecting_road_ids.add(connecting_road_id)
             except KeyError:
                 pass
 
         return _connecting_road_ids
 
-    def get_linked_road_ids(self) -> Set[int]:
+    def get_linked_road_ids(self) -> Set[str]:
         """
         Return a set of ids of the linked roads in this (direct) junction.
 
@@ -59,20 +59,20 @@ class Junction:
 
         Returns
         -------
-        Set[int]
-            Set of int road ids making up the linked roads in this junction.
+        Set[str]
+            Set of str road ids making up the linked roads in this junction.
         """
         _linked_road_ids = set()
         for connection_attributes in self._connection_attributes_list:
             try:
-                linked_road_id = int(connection_attributes["linkedRoad"])
+                linked_road_id = connection_attributes["linkedRoad"]
                 _linked_road_ids.add(linked_road_id)
             except KeyError:
                 pass
 
         return _linked_road_ids
 
-    def get_incoming_road_ids(self) -> Set[int]:
+    def get_incoming_road_ids(self) -> Set[str]:
         """
         Return a set of ids of the incoming roads to this junction.
 
@@ -80,18 +80,18 @@ class Junction:
 
         Returns
         -------
-        Set[int]
-            Set of int road ids making up the incoming roads to this junction.
+        Set[str]
+            Set of str road ids making up the incoming roads to this junction.
         """
         _incoming_road_ids = set()
         for connection_attributes in self._connection_attributes_list:
-            connecting_road_id = int(connection_attributes["incomingRoad"])
+            connecting_road_id = connection_attributes["incomingRoad"]
             _incoming_road_ids.add(connecting_road_id)
         return _incoming_road_ids
 
     def get_outgoing_road_ids(
-        self, road_ids_to_objects: Dict[int, Road], fail_on_key_error: bool = True
-    ) -> Set[int]:
+        self, road_ids_to_objects: Dict[str, Road], fail_on_key_error: bool = True
+    ) -> Set[str]:
         """
         Return a set of ids of the outgoing roads from this junction.
 
@@ -101,7 +101,7 @@ class Junction:
 
         Parameters
         ----------
-        road_ids_to_objects : Dict[int, Road]
+        road_ids_to_objects : Dict[str, Road]
             Dictionary linking road ids to Road objects.
         fail_on_key_error : bool, optional
             If True, connecting road ids from this junction not present in the
@@ -109,8 +109,8 @@ class Junction:
 
         Returns
         -------
-        Set[int]
-            A set of int roads ids making up the outgoing roads from this junction.
+        Set[str]
+            A set of str roads ids making up the outgoing roads from this junction.
 
         Raises
         ------
@@ -141,7 +141,7 @@ class Junction:
     @property
     def id(self):
         """Get the OpenDRIVE ID of this junction."""
-        return int(self["id"])
+        return self["id"]
 
     def closest_point_on_road(self, road_obj: Road) -> np.ndarray:
         """

--- a/pyxodr/road_objects/lane.py
+++ b/pyxodr/road_objects/lane.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List, Literal, Set, Tuple
+from typing import List, Set, Tuple
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/pyxodr/road_objects/network.py
+++ b/pyxodr/road_objects/network.py
@@ -99,14 +99,14 @@ class RoadNetwork:
 
             if pred_dict is not None and pred_dict["elementType"] == "road":
                 road.predecessor_data = (
-                    self.road_ids_to_object[int(pred_dict["elementId"])],
+                    self.road_ids_to_object[pred_dict["elementId"]],
                     ConnectionPosition.from_contact_point_str(
                         pred_dict["contactPoint"]
                     ),
                 )
             if succ_dict is not None and succ_dict["elementType"] == "road":
                 road.successor_data = (
-                    self.road_ids_to_object[int(succ_dict["elementId"])],
+                    self.road_ids_to_object[succ_dict["elementId"]],
                     ConnectionPosition.from_contact_point_str(
                         succ_dict["contactPoint"]
                     ),

--- a/pyxodr/road_objects/road.py
+++ b/pyxodr/road_objects/road.py
@@ -329,7 +329,7 @@ class Road:
     @property
     def id(self):
         """Get the OpenDRIVE ID of this road."""
-        return int(self["id"])
+        return self["id"]
 
     def _link_lane_sections(self):
         """
@@ -486,19 +486,19 @@ class Road:
         return lane_sections
 
     @cached_property
-    def successor_ids(self) -> Set[int]:
+    def successor_ids(self) -> Set[str]:
         """Get the OpenDRIVE IDs of the successor roads to this road."""
         _successor_ids = set()
         for successor_xml in self.road_xml.find("link").findall("successor"):
-            _successor_ids.add(int(successor_xml.attrib["elementId"]))
+            _successor_ids.add(successor_xml.attrib["elementId"])
         return _successor_ids
 
     @cached_property
-    def predecessor_ids(self) -> Set[int]:
+    def predecessor_ids(self) -> Set[str]:
         """Get the OpenDRIVE IDs of the predecessor roads to this road."""
         _predecessor_ids = set()
         for predecessor_xml in self.road_xml.find("link").findall("predecessor"):
-            _predecessor_ids.add(int(predecessor_xml.attrib["elementId"]))
+            _predecessor_ids.add(predecessor_xml.attrib["elementId"])
         return _predecessor_ids
 
     @cached_property
@@ -520,12 +520,12 @@ class Road:
     def junction_connecting_ids(self) -> Dict[str, Set[int]]:
         """Return the IDs of all junctions that connect to this road."""
         predecessor_junction_ids = [
-            int(predecessor_xml.attrib["elementId"])
+            predecessor_xml.attrib["elementId"]
             for predecessor_xml in self.road_xml.find("link").findall("predecessor")
             if predecessor_xml.attrib["elementType"] == "junction"
         ]
         successor_junction_ids = [
-            int(successor_xml.attrib["elementId"])
+            successor_xml.attrib["elementId"]
             for successor_xml in self.road_xml.find("link").findall("successor")
             if successor_xml.attrib["elementType"] == "junction"
         ]


### PR DESCRIPTION
Remove the casting of road IDs to ints, which was causing issues for string road IDs (allowed by the spec). I noticed that junction IDs were also being cast to ints, and str IDs are similarly allowed, so fixed this too.

Also fixed an issue where files with connections to and from the centre lane were throwing errors. My understanding is that this isn't strictly allowed by the OpenDRIVE spec (see description in the comment), but we don't need the entire import to fail.