### PR TITLE
Split Geometry Objects and Geometry Linestring Approximation

### DIFF
--- a/pyxodr/geometries/__init__.py
+++ b/pyxodr/geometries/__init__.py
@@ -1,3 +1,4 @@
+from pyxodr.geometries.line import Line
 from pyxodr.geometries.arc import Arc
 from pyxodr.geometries.cubic_polynom import CubicPolynom, ParamCubicPolynom
 from pyxodr.geometries.multi import MultiGeom

--- a/pyxodr/geometries/arc.py
+++ b/pyxodr/geometries/arc.py
@@ -17,11 +17,14 @@ class Arc(Geometry):
 
     def __init__(
         self,
-        curvature: float,
+        x_offset: float,
+        y_offset: float,
+        heading_offset: float,
         length: float,
+        curvature: float
     ):
+        Geometry.__init__(self, x_offset, y_offset, heading_offset, length)
         self.curvature = curvature
-        self.length = length
 
     def __call__(self, p_array: np.ndarray) -> np.ndarray:
         r"""

--- a/pyxodr/geometries/base.py
+++ b/pyxodr/geometries/base.py
@@ -1,12 +1,33 @@
-from abc import ABC, abstractmethod
-
+from abc import ABC
+from typing import Optional
 import numpy as np
 
-from pyxodr.utils.array import fix_zero_directions
+from enum import Enum
 
+class GeometryType(Enum):
+    ARC = 0
+    LINE = 1
+    POLYNOMINAL = 2
+    CUBIC_POLYNOM = 3
+    PARAMETRIC_CUBIC_CURVE = 4
+    SPIRAL = 5
 
 class Geometry(ABC):
     """Base class for geometry objects."""
+    def __init__(self, 
+        geometry_type: GeometryType,
+        x_offset: float,
+        y_offset: float,
+        heading_offset: float,
+        length: Optional[float] = None
+    ):
+        self.geometry_type = geometry_type
+        self.x_offset = x_offset
+        self.y_offset = y_offset
+        self.heading_offset = heading_offset
+        self.length = 1.0
+        if length is not None:
+            self.length = length
 
     @staticmethod
     def global_coords_from_offsets(
@@ -47,6 +68,17 @@ class Geometry(ABC):
 
         return global_coords
 
+    def evaluate_geometry(self, resolution: float):
+        num_samples = max(int(self.length / resolution), 2)
+
+        offsets = self(np.linspace(0.0, self.length, num_samples))
+        return Geometry.global_coords_from_offsets(
+                offsets,
+                self.x_offset,
+                self.y_offset,
+                self.heading_offset,
+            )
+        
     @staticmethod
     def compute_offset_vectors(
         local_offsets: np.ndarray,

--- a/pyxodr/geometries/line.py
+++ b/pyxodr/geometries/line.py
@@ -1,0 +1,71 @@
+import numpy as np
+from typing import Optional
+
+from pyxodr.geometries.base import Geometry, GeometryType
+
+
+class Line(Geometry):
+    """
+    Class representing an line geometry.
+
+    Parameters
+    ----------
+    length : float
+        Length [m] of the spiral.
+    curvStart : float
+        Curvature at the start of the spiral.
+    curvEnd : float
+        Curvature at the end of the spiral.
+    """
+
+    def __init__(
+        self,
+        x_offset: float,
+        y_offset: float,
+        heading_offset: float,
+        length: Optional[float] = None
+    ):
+        Geometry.__init__(self, GeometryType.LINE, x_offset, y_offset, heading_offset, length)
+
+    def __call__(self, p_array: np.ndarray) -> np.ndarray:
+        r"""
+        Return local (u, v) coordinates from an array of parameter $p \in [0.0, 1.0]$.
+
+        (u, v) coordinates are in their own x,y frame: start at origin, and initial
+        heading is along the x axis.
+        In this method the algorithm to do this has steps:
+        1) Compute the offset required to the p values to give us the correct starting
+          curvature
+        2) Compute the standard spiral
+        3) Translate to origin and rotate so initial direction is along x axis
+
+        Parameters
+        ----------
+        p_array : np.ndarray
+            p values $\in [0.0, 1.0]$ to compute parametric coordinates.
+
+        Returns
+        -------
+        np.ndarray
+            Array of local (u, v) coordinate pairs.
+        """
+        
+        # Construct direction vector
+        direction_vector = np.array(
+            [1.0, 0.0]
+        )
+        direction_tensor = np.tile(direction_vector, (len(p_array), 1))
+        return (
+            (direction_tensor.T * p_array).T
+        )
+        #geometry_coordinates.append(line_coordinates)
+
+        #return np.array([(0.0, 0.0), (1.0, 0.0)])
+    
+    def u_v_from_u(self, u_array: np.ndarray) -> np.ndarray:
+        """Raise an error; this geometry is parameteric with no v from u method."""
+        raise NotImplementedError("This geometry is only defined parametrically.")
+
+    def __str__(self) -> str:
+        return ""
+    

--- a/pyxodr/geometries/multi.py
+++ b/pyxodr/geometries/multi.py
@@ -133,7 +133,7 @@ class MultiGeom:
         # Repeat the final direction vector to give this the same shape as the centre
         # line
         # We repeat the final vector at the end as the best guess we have for the
-        # direction at the final coordinate is the preceeding direction.
+        # direction at the final coordinate is the preceding direction.
         distance_line_direction_vectors = np.vstack(
             (distance_line_direction_vectors, distance_line_direction_vectors[-1])
         )

--- a/pyxodr/geometries/spiral.py
+++ b/pyxodr/geometries/spiral.py
@@ -20,11 +20,14 @@ class Spiral(Geometry):
 
     def __init__(
         self,
-        length: float,
         curvStart: float,
         curvEnd: float,
+        x_offset: float,
+        y_offset: float,
+        heading_offset: float,
+        length: Optional[float] = None
     ):
-        self.length = length
+        Geometry.__init__(self, GeometryType.SPIRAL, x_offset, y_offset, heading_offset, length)
         self.curvStart = curvStart
         self.curvEnd = curvEnd
 


### PR DESCRIPTION
- The motivation behind this PR is to split the geometry objects (arc, line, polynomial) from the linestring approximation for the reference line.
- For my use case, I want to have access to the definitions of the underlying geometry objects and parameters (e.g. arc, line, poly), to be able to better visualize them: I am building an ODR visualizer, and want to expose the basic geometry building blocks to the user.

To achieve this, this commit does the following:
- It splits the geometry approximation for the reference line from the parsing part.
- The common geometry parameters (length, x/y/heading offsets) are now stored in the base class, so that they can be reused later.
- the geometry approximation has been unified so that all geometries behave similarly when called using the `__call__` operator: now, all geometries generate local u/v coordinates from a base parameter u.
- This allows to make the geometry approximation work independently of the geometry type.

This is just a quick draft to see if you are positive about this change. If you think it is useful, I will proceed and make a fully merge-ready PR out of it.

Below is an example of the project I am working on - it is a QGIS plugin to load ODR files, and I want to give the possibility to inspect the reference line segments. In the screenshot below, you can see one example reference line, which is a parametric cubic curve. By exposing the geometry elements as distinct features, the user can inspect these individually.
![image](https://github.com/user-attachments/assets/d20651a6-51b5-42f0-8dec-31b8a71c8ede)
